### PR TITLE
Update to use a newer supported image.

### DIFF
--- a/cicd/azure-pipeline/azure-build.yaml
+++ b/cicd/azure-pipeline/azure-build.yaml
@@ -1,5 +1,5 @@
 pool:
-  vmImage: 'ubuntu-16.04'
+  vmImage: 'ubuntu-20.04'
 
 trigger:
   branches:


### PR DESCRIPTION
The version 16 image is no longer supported by Azure. 

This PR updates this to use a supported image. 

See: https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml